### PR TITLE
Make regexp strings raw

### DIFF
--- a/providers/poczta.py
+++ b/providers/poczta.py
@@ -17,7 +17,7 @@ ID = __name__[10:]
 POPULARITY = 10
 
 def guess(number):
-    if re.search("^[A-Z]{2}\d{9}[A-Z]{2}$", number): # International Postal Union
+    if re.search(r"^[A-Z]{2}\d{9}[A-Z]{2}$", number): # International Postal Union
         return True
     return len(number) == 20 # domestic
         

--- a/providers/ups.py
+++ b/providers/ups.py
@@ -42,7 +42,7 @@ def track(number):
             for t in row('td').items():
                 td = t.text()
                 td = td.translate({ord(c): None for c in '\n\t\r'})
-                td = re.sub('\s+', ' ', td)
+                td = re.sub(r'\s+', ' ', td)
                 stage.append(td)
 
             stage_date = dateparser.parse("{} {}".format(stage[1], stage[2]), settings={'DATE_ORDER': 'YMD'})


### PR DESCRIPTION
Fixes deprecation warnings with Python >= 3.6:

    providers/ups.py:45: DeprecationWarning: invalid escape sequence \s
    providers/poczta.py:20: DeprecationWarning: invalid escape sequence \d